### PR TITLE
Fixed terrain out of bounds error

### DIFF
--- a/Assets/Scripts/Terrain/Mesh/MeshMapEditor.cs
+++ b/Assets/Scripts/Terrain/Mesh/MeshMapEditor.cs
@@ -190,8 +190,11 @@ public class MeshMapEditor : MonoBehaviour
         int startingXIndex = terrainX - brushRadius;
         int startingYIndex = terrainY - brushRadius;
 
+        // TODO: fix the bounds of the terrain cursor, otherwise we get index out of bounds error
         startingXIndex = Mathf.Max(0, startingXIndex);
+        startingXIndex = Mathf.Min(_terrainHeightMapResolution, startingXIndex);
         startingYIndex = Mathf.Max(0, startingYIndex);
+        startingYIndex = Mathf.Min(_terrainHeightMapResolution, startingYIndex);
 
 
         // Note: Terrain heights are 0-1, indexed as y,x


### PR DESCRIPTION
This occurs because the brush allows the player to reach a index higher than the resolution of the terrain heightmap

Closes #78 